### PR TITLE
Resolve compilation issues on do-like-javac update

### DIFF
--- a/working-benchmarks.yml
+++ b/working-benchmarks.yml
@@ -21,7 +21,7 @@ projects:
 #    clean: mvn clean
 
   imgscalr:
-    giturl: https://github.com/zcai1/imgscalr.git
+    giturl: https://github.com/opprop-benchmarks/imgscalr.git
     git-ref: 492cc8b3e53bcfe3e88fdac4c3bfcf44a0922c3d
     build: mvn compile
     clean: mvn clean

--- a/working-benchmarks.yml
+++ b/working-benchmarks.yml
@@ -1,7 +1,7 @@
 projects:
   jblas:
     giturl: https://github.com/opprop-benchmarks/jblas.git
-    build: mvn install
+    build: mvn compile
     clean: mvn clean
 
 #  exp4j:

--- a/working-benchmarks.yml
+++ b/working-benchmarks.yml
@@ -21,8 +21,8 @@ projects:
 #    clean: mvn clean
 
   imgscalr:
-    giturl: https://github.com/thebuzzmedia/imgscalr.git
-    git-ref: e1e1da77c12570f5c21d2f6ef42f0ce80c3fa092
+    giturl: https://github.com/zcai1/imgscalr.git
+    git-ref: 492cc8b3e53bcfe3e88fdac4c3bfcf44a0922c3d
     build: mvn compile
     clean: mvn clean
 


### PR DESCRIPTION
Resolve compilation issues on https://github.com/opprop/do-like-javac/pull/18

Replaced "mvn install" with "mvn compile" to avoid warnings about javadoc. Also replaced "thebuzzmedia/imgscalr" with "opprop-benchmarks/imgscalr" to resolve Java 5 not supported issue.